### PR TITLE
Add trim to twitter links to remove redundant space

### DIFF
--- a/CodeMobile/DetailViewController.swift
+++ b/CodeMobile/DetailViewController.swift
@@ -112,7 +112,7 @@ class DetailViewController: UIViewController, UISplitViewControllerDelegate, UIT
         
         print("www.twitter.com/\(twitterURL)")
         
-        let screenName = twitterURL.replacingOccurrences(of: "@", with: "", options: .literal, range: nil)
+        let screenName = twitterURL.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "@", with: "", options: .literal, range: nil)
         let appURL = URL(string: "twitter://user?screen_name=\(screenName)")!
         let webURL = URL(string: "https://twitter.com/\(screenName)")!
         


### PR DESCRIPTION
Trim twitter links to resolve crash when excess spaces were found.  

Closes #13 